### PR TITLE
fix flakiness in testPojoConversion.java

### DIFF
--- a/karate-core/src/test/java/com/intuit/karate/JsonUtilsTest.java
+++ b/karate-core/src/test/java/com/intuit/karate/JsonUtilsTest.java
@@ -39,7 +39,7 @@ class JsonUtilsTest {
     void testBeanConversion() {
         SimplePojo pojo = new SimplePojo();
         String s = JsonUtils.toJson(pojo);
-        assertEquals("{\"bar\":0,\"foo\":null}", s);
+        Match.that(s).isEqualTo("{\"bar\":0,\"foo\":null}");
         Map<String, Object> map = Json.of(pojo).asMap();
         Match.that(map).isEqualTo("{ foo: null, bar: 0 }");
     }
@@ -55,8 +55,7 @@ class JsonUtilsTest {
         p2.setFoo("p2");
         pojo.setBan(Arrays.asList(p1, p2));
         String s = JsonUtils.toJson(pojo);
-        String expected = "{\"bar\":1,\"foo\":\"testFoo\",\"baz\":null,\"ban\":[{\"bar\":0,\"foo\":\"p1\",\"baz\":null,\"ban\":null},{\"bar\":0,\"foo\":\"p2\",\"baz\":null,\"ban\":null}]}";
-        assertEquals(s, expected);
+        Match.that(s).isEqualTo("{\"bar\":1,\"foo\":\"testFoo\",\"baz\":null,\"ban\":[{\"bar\":0,\"foo\":\"p1\",\"baz\":null,\"ban\":null},{\"bar\":0,\"foo\":\"p2\",\"baz\":null,\"ban\":null}]}");
         ComplexPojo temp = (ComplexPojo) JsonUtils.fromJson(s, ComplexPojo.class.getName());
         assertEquals(temp.getFoo(), "testFoo");
         assertEquals(2, temp.getBan().size());
@@ -64,7 +63,7 @@ class JsonUtilsTest {
         assertEquals(temp.getFoo(), "testFoo");
         assertEquals(2, temp.getBan().size());
         s = XmlUtils.toXml(pojo);
-        assertEquals(s, "<root><bar>1</bar><foo>testFoo</foo><baz/><ban><bar>0</bar><foo>p1</foo><baz/><ban/></ban><ban><bar>0</bar><foo>p2</foo><baz/><ban/></ban></root>");
+        Match.that(s).isEqualTo("<root><bar>1</bar><foo>testFoo</foo><baz/><ban><bar>0</bar><foo>p1</foo><baz/><ban/></ban><ban><bar>0</bar><foo>p2</foo><baz/><ban/></ban></root>");
     }
 
     @Test


### PR DESCRIPTION
### Description

- Relevant Issues : `testPojoConversion` and `testBeanConversion` in `com/intuit/karate/JsonUtilsTest.java` are flaky because the XML/Json format strings converted from `complexPojo` and `SimplePojo` objects are non-derministic; comparing two strings directly will fail sometimes. I fixed the bug comparing the Json/XML format string with expected answer using `Match.isEqualto()` method since this parse the format string into object and compare them deterministically. 

- Type of change :
  - [ ] New feature
  - [ ] Bug fix for existing feature
  - [ ] Code quality improvement
  - [x] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation
